### PR TITLE
Fix doc generation - want vars instead of symbols

### DIFF
--- a/src/grimoire/core.clj
+++ b/src/grimoire/core.clj
@@ -265,7 +265,7 @@
 (defn write-docs-for-ns
   [dirs ns]
   (let [[version-dir include-dir]         dirs
-        ns-vars                           (->> (ns-publics ns) keys (remove var-blacklist))
+        ns-vars                           (->> (ns-publics ns) vals (remove var-blacklist))
         macros                            (filter macro? ns-vars)
         fns                               (filter #(and (fn? @%1)
                                                         (not (macro? %1)))


### PR DESCRIPTION
Seems this was introduced recently - https://github.com/arrdem/grimoire/commit/6fccea039d21ae65882bbe0671269691aac572f6#diff-65
