### PR TITLE
Comparing -> with as->

### DIFF
--- a/_includes/1.6.0/clojure.core/as_DASH__GT/examples.md
+++ b/_includes/1.6.0/clojure.core/as_DASH__GT/examples.md
@@ -9,4 +9,22 @@ user=> (as-> 1 a (inc a) (inc a) (inc a))
 {% endraw %}
 {% endhighlight %}
 
+### Example 1
+[permalink](#example-1)
+{% highlight clojure %}
+{% raw %}
+; Using the simple threading macro ->
+(-> shape
+  (rotate 30)
+  (scale 1.2)
+  (translate 10 -2))
+
+; Using as->
+(as-> shape s
+  (rotate s 30)
+  (scale s 1.2)
+  (translate s 10 -2))
+{% endraw %}
+{% endhighlight %}
+
 [Please add examples!](https://github.com/arrdem/grimoire/edit/master/_includes/1.6.0/clojure.core/as_DASH__GT/examples.md)


### PR DESCRIPTION
Comparing the alias threading macro (is that a thing?) with the regular threading macro to illustrate readability improvement.
