### PR TITLE
Make kw/symbol/comment syntax highlighting more visible

### DIFF
--- a/resources/public/css/syntax.css
+++ b/resources/public/css/syntax.css
@@ -1,12 +1,12 @@
 .highlight .hll { background-color: #ffc; }
-.highlight .c { color: #999; } /* Comment */
+.highlight .c { color: #888; } /* Comment */
 .highlight .err { color: #a00; background-color: #faa } /* Error */
 .highlight .k { color: #069; } /* Keyword */
 .highlight .o { color: #555 } /* Operator */
 .highlight .cm { color: #09f; font-style: italic } /* Comment.Multiline */
 .highlight .cp { color: #099 } /* Comment.Preproc */
-.highlight .c1 { color: #999; } /* Comment.Single */
-.highlight .cs { color: #999; } /* Comment.Special */
+.highlight .c1 { color: #888; } /* Comment.Single */
+.highlight .cs { color: #888; } /* Comment.Special */
 .highlight .gd { background-color: #fcc; border: 1px solid #c00 } /* Generic.Deleted */
 .highlight .ge { font-style: italic } /* Generic.Emph */
 .highlight .gr { color: #f00 } /* Generic.Error */
@@ -53,7 +53,7 @@
 .highlight .sx { color: #c30 } /* Literal.String.Other */
 .highlight .sr { color: #3aa } /* Literal.String.Regex */
 .highlight .s1 { color: #c30 } /* Literal.String.Single */
-.highlight .ss { color: #fc3 } /* Literal.String.Symbol */
+.highlight .ss { color: #a80 } /* Literal.String.Symbol */
 .highlight .bp { color: #366 } /* Name.Builtin.Pseudo */
 .highlight .vc { color: #033 } /* Name.Variable.Class */
 .highlight .vg { color: #033 } /* Name.Variable.Global */


### PR DESCRIPTION
I based this PR off of the `develop` branch.  Is that right, or do you want them off of `master`?  You might want to put your preference in the "Contributing" docs.

Keywords/symbols used to be a light yellow that was hard to read on
the light background, changed to use something almost equal to the
yellow from Solarized.

For comments, the current grey would be fine on a white bg, but on
the light grey code example bg, it needs to be slightly darker for
contrast.  It could go even darker, to #808080 or so.
