### PR TITLE
Call search function on page load to catch browser back button in chrome

### DIFF
--- a/resources/cheatsheet.html
+++ b/resources/cheatsheet.html
@@ -143,6 +143,7 @@ tr.even {
        };
       };
      });
+    $('#search').keyup();
   })
   </script>
 </head>


### PR DESCRIPTION
Fixes #119 
Tested only in Chrome.
