### PR TITLE
Fix local installation on MacOSX.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ should get you started:
 Requires:
 
  - GNU Awk (MacOSX only)
+ - GNU Head (MacOSX only)
  - Perl
  - Leiningen (-> Maven)
  - Git

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Requires:
 
  - GNU Awk (MacOSX only)
  - GNU Head (MacOSX only)
+ - Pygments
  - Perl
  - Leiningen (-> Maven)
  - Git

--- a/cheatsheet.sh
+++ b/cheatsheet.sh
@@ -4,6 +4,9 @@ set -e
 mkdir -p dat
 pushd dat > /dev/null
 
+[ -f `which ghead` ] && HEAD=`which ghead` || HEAD=`which head`
+echo "[debug] Using " $HEAD " for head imp'l"
+
 if [ ! -d "clojure-cheatsheets" ]; then
   git clone https://github.com/arrdem/clojure-cheatsheets
 fi
@@ -17,7 +20,7 @@ popd > /dev/null
 popd > /dev/null
 cp dat/clojure-cheatsheets/src/clj-jvm/cheatsheet-full.html .
 sed  -i -e 1,3d cheatsheet-full.html
-head -n -2 cheatsheet-full.html > _cheatsheet
+$HEAD -n -2 cheatsheet-full.html > _cheatsheet
 mv _cheatsheet cheatsheet-full.html
 perl -i -p -e 's%http://conj.io/%{{ site.baseurl }}%g' cheatsheet-full.html
 perl -i -p -e 's%/1.6.0%\/{{ site.clojure_version }}%g' cheatsheet-full.html

--- a/dat.sh
+++ b/dat.sh
@@ -73,7 +73,7 @@ install_docs() {
     git_get "git@github.com:$1/$2.git"
     rm "./$2"
     dat="$GIT_DAT/$1/$2"
-    src="$DAT/$3/$4"
+    src="$dat/$3/$4"
     tgt="$DOCS/$3/$4"
 
     if [ -d "$dat" ]


### PR DESCRIPTION
Prefers GNU head over BSD head for compatibility and lists the required Pygments dependency.  Changes to the install scripts reflects this fix and patches a typo for the correct installation directory.