### PR TITLE
Use https:// scheme for google fonts

### DIFF
--- a/src/main/grimoire/web/layout.clj
+++ b/src/main/grimoire/web/layout.clj
@@ -24,7 +24,7 @@
     (str base-url "public/css/lanyon.css")
     (str base-url "public/css/headings.css"))
    (map page/include-css css)
-   [:link {:href "http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400"
+   [:link {:href "https://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400"
            :rel "stylesheet"}]
    [:link {:href (str base-url "public/apple-touch-icon-precomposed.png") :sizes "144x144" :rel "apple-touch-icon-precomposed"}]
    [:link {:href (str base-url "public/favicon.ico") :rel "shortcut icon"}]])


### PR DESCRIPTION
Chrome 51 squeals with: 

Mixed Content: The page at 'https://www.conj.io/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700|PT+Sans:400'. This request has been blocked; the content must be served over HTTPS.