### PR TITLE
Fix to escape searching symbol

### DIFF
--- a/src/main/grimoire/web/routes.clj
+++ b/src/main/grimoire/web/routes.clj
@@ -315,7 +315,7 @@
                                               (t/thing->name v-thing)
                                               "clj"
                                               ns
-                                              symbol)
+                                              (util/munge symbol))
                            new-req    (-> request
                                           (assoc :uri new-uri)
                                           (dissoc :context :path-info))]
@@ -347,7 +347,7 @@
                                                 (t/thing->name v-thing)
                                                 platform
                                                 ns
-                                                symbol)
+                                                (util/munge symbol))
                              new-req    (-> request
                                             (assoc :uri new-uri)
                                             (dissoc :context :path-info))]


### PR DESCRIPTION
## Expected behavior
 - `https://conj.io/search/v1/clj/clojure.core/empty%3F/` should redirect to `/store/v0/org.clojure/clojure/1.9.0/clj/clojure.core/empty%3F`

## Actual behavior
 - `https://conj.io/search/v1/clj/clojure.core/empty%3F/` redirects to `/store/v0/org.clojure/clojure/1.9.0/clj/clojure.core/empty?` and `empty` document is show.